### PR TITLE
Resolve some deployment blockers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN cd ${LAMBDA_TASK_ROOT} && poetry install --no-interaction --no-ansi --no-roo
 
 COPY ./ ${LAMBDA_TASK_ROOT}/
 
-CMD ["src/main.handler"]
+CMD ["src.main.handler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,6 @@ COPY poetry.lock pyproject.toml ${LAMBDA_TASK_ROOT}/
 RUN cd ${LAMBDA_TASK_ROOT} && poetry install --no-interaction --no-ansi --no-root --only main
 
 COPY ./ ${LAMBDA_TASK_ROOT}/
+ENV PYTHONPATH "${PYTHONPATH}:${LAMBDA_TASK_ROOT}"
 
 CMD ["src.main.handler"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Test it </br>
 - Next time you will deploy the server will be exposed under your domain.
 
 9. Deploy to AWS
+Note - if you are building the docker image from a mac, change `architecture: x86_64` to `architecture: arm64` in the `serverless.yml` file.
 ```
 ./scripts/deploy
 ```

--- a/serverless.yml
+++ b/serverless.yml
@@ -43,7 +43,6 @@ provider:
   memorySize: 1024 # MB
   timeout: 30
   endpointType: edge
-  lambdaHashingVersion: 20201221
   # apiGateway:
   #   metrics: true
   tracing:

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,6 +59,8 @@ provider:
         cacheFrom:
           # This is the path where the serverless framework will put the image in ECR when created for the first time.
           - ${AWS::AccountId}.dkr.ecr.${self:provider.region}.amazonaws.com/serverless-fastapibackendservice-${self:provider.stage}:fastapi-backend-server
+        # build container to match the architecture: x86_64 param
+        platform: linux/amd64
   iamRoleStatements:  # handles the permissions of the lambda
     # XRay
     - Effect: Allow

--- a/serverless.yml
+++ b/serverless.yml
@@ -80,6 +80,8 @@ functions:
   app:
     image:
       name: fastapi-backend-server
+    architecture: x86_64 # default
+    # architecture: arm64 # works for docker images built on Mac M1/M2/M3/etc machines
     environment:
       STAGE: ${self:provider.stage}
 


### PR DESCRIPTION
@roy-pstr Thanks for sharing the repo. I used it as a starting point for deploy a service and ran across some small things I resolved to get it work on my setup. Maybe these changes are helpful for others.

Changes:
- docker: add PYTHONPATH to resolve module not found error
- docker: use dot syntax to refer to handler function
- docs: add note about architecture on macs vs other machines
